### PR TITLE
Enable 'Run Simulation' button and track initial ParFlow run

### DIFF
--- a/src/components/core/Sandtank/template.html
+++ b/src/components/core/Sandtank/template.html
@@ -59,6 +59,8 @@
             @click="runSimulation"
             :loading="simulationLoading"
             color="primary"
+            :outlined="!needRunSimulation"
+            :disabled="!needRunSimulation"
           >
             Run Simulation
           </v-btn>

--- a/src/components/core/Sandtank/template.html
+++ b/src/components/core/Sandtank/template.html
@@ -59,8 +59,6 @@
             @click="runSimulation"
             :loading="simulationLoading"
             color="primary"
-            :outlined="!needRunSimulation"
-            :disabled="!needRunSimulation"
           >
             Run Simulation
           </v-btn>

--- a/src/store/simulation.js
+++ b/src/store/simulation.js
@@ -48,9 +48,6 @@ export default {
         state.initialRun
       );
     },
-    SIM_INITIAL_RUN(state) {
-      return state.initialRun;
-    },
   },
   mutations: {
     SIM_LEFT_SET(state, left) {

--- a/src/store/simulation.js
+++ b/src/store/simulation.js
@@ -13,6 +13,7 @@ export default {
     runTimeStep: 1,
     busy: false,
     lastRun: { left: null, right: null },
+    initialRun: true,
   },
   getters: {
     SIM_LEFT(state) {
@@ -43,8 +44,12 @@ export default {
       return (
         state.running ||
         state.left !== state.lastRun.left ||
-        state.right !== state.lastRun.right
+        state.right !== state.lastRun.right ||
+        state.initialRun
       );
+    },
+    SIM_INITIAL_RUN(state) {
+      return state.initialRun;
     },
   },
   mutations: {
@@ -79,6 +84,7 @@ export default {
   },
   actions: {
     SIM_RUN_MODELS({ state, dispatch }) {
+      state.initialRun = false;
       state.running = true;
       const run = {
         left: state.left,


### PR DESCRIPTION
- Removed disabling of `Run Simulation` button when prior run exists
- Grayed output of initial ParFlow run by adding `initialRun` variable to `simulation.js` which is true until the `Run Simulation` button is clicked and `SIM_RUN_MODELS` is called